### PR TITLE
Implement: cas, get_from_last, prepend, quit, replace, server_by_key, set_servers, set_prefix_key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fakememcached (0.1.0)
+    fakememcached (0.1.1)
 
 GEM
   remote: http://rubygems.org/
@@ -10,6 +10,7 @@ GEM
     rspec (1.3.2)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/fakememcached.gemspec
+++ b/fakememcached.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-require 'lib/fakememcached/version'
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+require 'fakememcached/version'
 
 Gem::Specification.new do |s|
   s.name = %q{fakememcached}

--- a/fakememcached.gemspec
+++ b/fakememcached.gemspec
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'fakememcached/version'
+require 'date'
 
 Gem::Specification.new do |s|
   s.name = %q{fakememcached}

--- a/lib/fakememcached.rb
+++ b/lib/fakememcached.rb
@@ -8,9 +8,21 @@ class FakeMemcached
 
   @@server_data = {}
 
+  LOCAL_DEFAULTS = {:default_ttl => 10, :prefix_delimiter => ''}
+
   def initialize(servers = nil, opts = {})
-    @options = Memcached::DEFAULTS.merge(opts)
-    @options.delete_if {|k, v| !Memcached::DEFAULTS.keys.include?(k)}
+    @options = {}
+
+    if defined?(Memcached::DEFAULTS)
+      @options = Memcached::DEFAULTS.merge(opts)
+      @options.delete_if { |k, v| !Memcached::DEFAULTS.keys.include?(k) }
+    else
+      #Jruby memcached does not have the magic constant DEFAULTS.
+      #added this to help with this case.
+      @options = LOCAL_DEFAULTS.merge(opts)
+      @options.delete_if { |k, v| !LOCAL_DEFAULTS.keys.include?(k) }
+    end
+
     @default_ttl = options[:default_ttl]
 
     if servers == nil || servers == []

--- a/lib/fakememcached.rb
+++ b/lib/fakememcached.rb
@@ -111,9 +111,10 @@ class FakeMemcached
   def cas(key, ttl = @default_ttl, marshal = true, flags = nil)
     raise Memcached::ClientError, 'CAS not enabled for this Memcached instance' unless options[:support_cas]
 
+    initial = get(key, false)
     value = get(key, marshal)
     new_value = yield(value)
-    if get(key, marshal) == value
+    if get(key, false) == initial
       set(key, new_value, ttl, marshal, flags)
     else
       raise Memcached::NotStored

--- a/lib/fakememcached.rb
+++ b/lib/fakememcached.rb
@@ -31,7 +31,7 @@ class FakeMemcached
     if servers
       # Validate format
       servers.each do |server|
-        if !server.is_a?(String) || File.socket?(server) || server =~ /^[\w\d\.-]+(:\d{1,5}){0,2}$/
+        unless server.is_a?(String) && (File.socket?(server) || server =~ /^[\w\d\.-]+(:\d{1,5}){0,2}$/)
           raise ArgumentError, "Servers must be either in the format 'host:port[:weight]' (e.g., 'localhost:11211' or  'localhost:11211:10') for a network server, or a valid path to a Unix domain socket (e.g., /var/run/memcached)."
         end
       end

--- a/lib/fakememcached.rb
+++ b/lib/fakememcached.rb
@@ -2,27 +2,35 @@ require 'fakememcached/cache_entry'
 
 class FakeMemcached
   def initialize(servers = nil, opts = {})
-    @servers = servers
     @default_ttl = opts[:default_ttl] || 1_000_000
     @data = {}
+    set_servers(servers)
+    set_prefix_key(opts[:prefix_key] || opts[:namespace])
   end
 
-  # NOT IMPLEMENTED:
-  # * cas
-  # * get_from_last
-  # * prepend
-  # * quit
-  # * replace
-  # * server_by_key
-  # * set_servers
-  # * set_prefix_key
+  def set_servers(servers)
+    @servers = servers
+  end
+
+  def servers
+    @servers || []
+  end
+
+  def set_prefix_key(prefix_key)
+    @prefix_key = prefix_key
+  end
+  alias :set_namespace :set_prefix_key
 
   def prefix_key
-    ""
+    @prefix_key || ''
   end
   alias :namespace :prefix_key
   
-  def set(key, value, ttl = nil, marshal = true, flags = nil)
+  def reset(current_servers = nil)
+    set_servers(current_servers) if current_servers
+  end
+
+  def set(key, value, ttl = @default_ttl, marshal = true, flags = nil)
     @data[key] = CacheEntry.new(value, ttl.nil? || ttl.zero? ? @default_ttl : ttl, marshal)
   end
 
@@ -33,6 +41,67 @@ class FakeMemcached
       set(key, value, ttl, marshal, flags)
       "STORED\r\n"
     end
+  end
+
+  def increment(key, offset = 1)
+    if has_unexpired_key?(key)
+      @data[key].increment(offset)
+      @data[key].to_i
+    end
+  end
+
+  def decrement(key, amount = 1)
+    if has_unexpired_key?(key)
+      @data[key].decrement(amount)
+      @data[key].to_i
+    end
+  end
+
+  alias :incr :increment
+  alias :decr :decrement
+
+  def replace(key, value, ttl = @default_ttl, marshal = true, flags = nil)
+    if @data.include?(key)
+      set(key, value, ttl, marshal, flags)
+    else
+      raise Memcached::NotFound
+    end
+  end
+
+  def append(key, value)
+    set(key, get(key, false).to_s + value.to_s, nil, false)
+  end
+
+  def prepend(key, value)
+    set(key, value.to_s + get(key, false).to_s, nil, false)
+  end
+
+  def cas(key, ttl = @default_ttl, marshal = true, flags = nil)
+    value = get(key, marshal)
+    new_value = yield(value)
+    if get(key, marshal) == value
+      set(key, new_value, ttl, marshal, flags)
+    else
+      raise Memcached::NotStored
+    end
+  end
+  alias :compare_and_swap :cas
+  
+  def delete(key)
+    @data.delete(key) if has_unexpired_key?(key)
+  end
+
+  def flush
+    @data.clear
+  end
+  alias :flush_all :flush
+
+  def reset(current_servers = nil)
+    @servers = current_servers
+  end
+
+  def quit
+    self
   end
 
   def get(key, marshal = true)
@@ -48,42 +117,10 @@ class FakeMemcached
       end
     end
   end
+  alias :get_from_last :get
 
-  def increment(key, offset = 1)
-    if has_unexpired_key?(key)
-      @data[key].increment(offset)
-      @data[key].to_i
-    end
-  end
-  alias :incr :increment
-
-  def decrement(key, amount = 1)
-    if has_unexpired_key?(key)
-      @data[key].decrement(amount)
-      @data[key].to_i
-    end
-  end
-  alias :decr :decrement
-
-  def append(key, value)
-    set(key, get(key, false).to_s + value.to_s, nil, false)
-  end
-  
-  def delete(key)
-    @data.delete(key) if has_unexpired_key?(key)
-  end
-
-  def servers
-    @servers
-  end
-
-  def flush
-    @data.clear
-  end
-  alias :flush_all :flush
-
-  def reset(current_servers = nil)
-    @servers = current_servers
+  def server_by_key(key)
+    servers.first
   end
 
   def stats(subcommand = nil)

--- a/lib/fakememcached/version.rb
+++ b/lib/fakememcached/version.rb
@@ -2,7 +2,7 @@ class FakeMemcached
   module Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 1
+    PATCH = 2
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end
 end


### PR DESCRIPTION
See subject.  Also starts moving toward actually support for prefix keys -- it now tracks them, but doesn't actually use it yet.

I've also reorganized the methods to be in the same order as the Memcached gem so as to more easily see what we're missing.